### PR TITLE
main marge

### DIFF
--- a/apis/server-github/README.md
+++ b/apis/server-github/README.md
@@ -1,0 +1,59 @@
+# server-github
+
+
+> MCP server for GitHub API: file ops, repo management, issues, PRs, and search
+
+## Overview
+
+MCP Server for the GitHub API enabling file operations, repository management, issue/PR management, and search functionality. It supports creating and updating files, managing branches, searching code and repositories, and interacting with GitHub's full API surface. This project has been deprecated in favor of the official github/github-mcp-server.
+
+## Metadata
+
+- **Version**: 1.0.0
+- **Owner**: modelcontextprotocol
+- **Company**: modelcontextprotocol
+- **Status**: deprecated
+- **Lifecycle**: deprecated
+
+## Authentication
+
+This MCP server uses **api-key** for authentication.
+
+### API Key Authentication
+
+To authenticate, include your API key in the request headers:
+
+```
+Authorization: Bearer YOUR_API_KEY
+```
+
+Contact the server owner to obtain an API key.
+
+## Contact
+
+- **Owner**: modelcontextprotocol
+
+
+## Endpoint
+
+Endpoint URL will be provided upon deployment.
+
+## Documentation
+
+For more details, see: https://github.com/modelcontextprotocol/servers-archived/tree/main/src/github
+
+## Tags
+
+`github`, `api`, `repository`, `mcp`, `version-control`, `git`, `issues`, `pull-requests`
+
+## Usage
+
+To use this MCP server:
+
+1. Ensure you have the appropriate authentication credentials
+2. Connect to the endpoint using an MCP-compatible client
+3. Follow the API specification defined in `openapi.json`
+
+## Support
+
+For support or questions, please contact modelcontextprotocol.

--- a/apis/server-github/metadata.json
+++ b/apis/server-github/metadata.json
@@ -1,0 +1,26 @@
+{
+  "name": "server-github",
+  "description": "MCP Server for the GitHub API enabling file operations, repository management, issue/PR management, and search functionality. It supports creating and updating files, managing branches, searching code and repositories, and interacting with GitHub\u0027s full API surface. This project has been deprecated in favor of the official github/github-mcp-server.",
+  "summary": "MCP server for GitHub API: file ops, repo management, issues, PRs, and search",
+  "version": "1.0.0",
+  "company": "modelcontextprotocol",
+  "status": "deprecated",
+  "lifecycle": "deprecated",
+  "owner": "modelcontextprotocol",
+  "authMethod": "api-key",
+  "contactEmail": "",
+  "endpointUrl": "",
+  "documentationUrl": "https://github.com/modelcontextprotocol/servers-archived/tree/main/src/github",
+  "tags": [
+    "github",
+    "api",
+    "repository",
+    "mcp",
+    "version-control",
+    "git",
+    "issues",
+    "pull-requests"
+  ],
+  "customProperties": {},
+  "repositoryUrl": "https://github.com/modelcontextprotocol/server-github"
+}

--- a/apis/server-github/openapi.json
+++ b/apis/server-github/openapi.json
@@ -1,0 +1,49 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "server-github",
+    "summary": "MCP server for GitHub API: file ops, repo management, issues, PRs, and search",
+    "description": "MCP Server for the GitHub API enabling file operations, repository management, issue/PR management, and search functionality. It supports creating and updating files, managing branches, searching code and repositories, and interacting with GitHub\u0027s full API surface. This project has been deprecated in favor of the official github/github-mcp-server.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "modelcontextprotocol",
+      "email": ""
+    }
+  },
+  "servers": [],
+  "paths": {
+    "/health": {
+      "get": {
+        "summary": "Health check endpoint",
+        "description": "Returns the health status of the MCP server",
+        "operationId": "getHealth",
+        "responses": {
+          "200": {
+            "description": "Healthy"
+          },
+          "503": {
+            "description": "Unhealthy"
+          }
+        }
+      }
+    },
+    "/mcp": {
+      "post": {
+        "summary": "MCP protocol endpoint",
+        "description": "Main endpoint for MCP protocol communication",
+        "operationId": "mcpEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tatus } finally { if ($) { echo 2eebce4cd7cf47c5a9b4589fb74dc087=$ } else { echo 2eebce4cd7cf47c5a9b4589fb74dc087=$ } }
+++ b/tatus } finally { if ($) { echo 2eebce4cd7cf47c5a9b4589fb74dc087=$ } else { echo 2eebce4cd7cf47c5a9b4589fb74dc087=$ } }
@@ -1,0 +1,49 @@
+
+                   SSUUMMMMAARRYY OOFF LLEESSSS CCOOMMMMAANNDDSS
+
+      Commands marked with * may be preceded by a number, _N.
+      Notes in parentheses indicate the behavior if _N is given.
+      A key preceded by a caret indicates the Ctrl key; thus ^K is ctrl-K.
+
+  h  H                 Display this help.
+  q  :q  Q  :Q  ZZ     Exit.
+ ---------------------------------------------------------------------------
+
+                           MMOOVVIINNGG
+
+  e  ^E  j  ^N  CR  *  Forward  one line   (or _N lines).
+  y  ^Y  k  ^K  ^P  *  Backward one line   (or _N lines).
+  ESC-j             *  Forward  one file line (or _N file lines).
+  ESC-k             *  Backward one file line (or _N file lines).
+  f  ^F  ^V  SPACE  *  Forward  one window (or _N lines).
+  b  ^B  ESC-v      *  Backward one window (or _N lines).
+  z                 *  Forward  one window (and set window to _N).
+  w                 *  Backward one window (and set window to _N).
+  ESC-SPACE         *  Forward  one window, but don't stop at end-of-file.
+  ESC-b             *  Backward one window, but don't stop at beginning-of-file.
+  d  ^D             *  Forward  one half-window (and set half-window to _N).
+  u  ^U             *  Backward one half-window (and set half-window to _N).
+  ESC-)  RightArrow *  Right one half screen width (or _N positions).
+  ESC-(  LeftArrow  *  Left  one half screen width (or _N positions).
+  ESC-}  ^RightArrow   Right to last column displayed.
+  ESC-{  ^LeftArrow    Left  to first column.
+  F                    Forward forever; like "tail -f".
+  ESC-F                Like F but stop when search pattern is found.
+  r  ^R  ^L            Repaint screen.
+  R                    Repaint screen, discarding buffered input.
+        ---------------------------------------------------
+        Default "window" is the screen height.
+        Default "half-window" is half of the screen height.
+ ---------------------------------------------------------------------------
+
+                          SSEEAARRCCHHIINNGG
+
+  /_p_a_t_t_e_r_n          *  Search forward for (_N-th) matching line.
+  ?_p_a_t_t_e_r_n          *  Search backward for (_N-th) matching line.
+  n                 *  Repeat previous search (for _N-th occurrence).
+  N                 *  Repeat previous search in reverse direction.
+  ESC-n             *  Repeat previous search, spanning files.
+  ESC-N             *  Repeat previous search, reverse dir. & spanning files.
+  ^O^N  ^On         *  Search forward for (_N-th) OSC8 hyperlink.
+  ^O^P  ^Op         *  Search backward for (_N-th) OSC8 hyperlink.
+  ^O^L  ^Ol            Jump to the currently selected OSC8 hyperlink.


### PR DESCRIPTION
This pull request introduces the initial documentation and metadata for the `server-github` MCP server, which provides GitHub API integration for file operations, repository management, issue and PR handling, and search. The project is marked as deprecated in favor of the official `github/github-mcp-server`. The most important changes are grouped by documentation, metadata, and API specification.

Documentation:

* Added a comprehensive `README.md` for the `server-github` MCP server, detailing its features, authentication method, usage instructions, and deprecation notice.

Metadata:

* Introduced a `metadata.json` file describing the server's purpose, version, tags, owner, and links to documentation and repository, with clear deprecation status.

API Specification:

* Added an `openapi.json` file defining the MCP server's OpenAPI schema, including health check and protocol endpoints, as well as metadata and contact information.